### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,26 +6,16 @@
     "production": ["default", "!{projectRoot}/**/*.spec.rs"]
   },
   "targetDefaults": {
-    "build": {
-      "cache": true
-    },
-    "test": {
-      "cache": true
-    },
-    "lint": {
-      "cache": true
-    }
+    "build": { "cache": true },
+    "test": { "cache": true },
+    "lint": { "cache": true }
   },
   "plugins": ["@monodon/rust"],
   "release": {
     "projects": ["crates/*"],
     "projectsRelationship": "fixed",
-    "releaseTag": {
-      "pattern": "v{version}"
-    },
-    "version": {
-      "conventionalCommits": true
-    },
+    "releaseTag": { "pattern": "v{version}" },
+    "version": { "conventionalCommits": true },
     "changelog": {
       "projectChangelogs": false,
       "workspaceChangelog": {
@@ -40,5 +30,6 @@
       "push": true
     }
   },
-  "analytics": false
+  "analytics": false,
+  "nxCloudId": "6a4c1b257e59d45188ffaac0"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/5f482e1881ecd800056b4eef/workspaces/6a4c1b257e59d45188ffaac0

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.