### PR TITLE
fix(spectatui): ignore key-release events on Windows

### DIFF
--- a/crates/spectatui/src/event.rs
+++ b/crates/spectatui/src/event.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crossterm::event::{self, Event as CtEvent, KeyEvent, MouseEvent};
+use crossterm::event::{self, Event as CtEvent, KeyEvent, KeyEventKind, MouseEvent};
 use tokio::sync::mpsc;
 
 use spectatui_core::speckit::watch::FsEvent;
@@ -43,7 +43,9 @@ impl EventStream {
                 if event::poll(tick_rate).unwrap_or(false) {
                     match event::read() {
                         Ok(CtEvent::Key(key)) => {
-                            if tx_clone.send(AppEvent::Key(key)).is_err() {
+                            if key.kind == KeyEventKind::Press
+                                && tx_clone.send(AppEvent::Key(key)).is_err()
+                            {
                                 return;
                             }
                         }


### PR DESCRIPTION
Fix: Confirm dialogs instantly dismissed on Windows

Symptom: On Windows, pressing a key that opens a confirmation dialog (e.g. q → "Quit Spectatui?") dismisses it in the same keystroke. The user never gets to interact with it. Also affects the CLI confirm dialog.

Cause: crossterm 0.28 emits a KeyEvent for both key press and key release on Windows. The event loop in event.rs forwarded both, so the release event was handled a second time by the newly-opened dialog's key bindings.

Fix: Filter incoming key events to KeyEventKind::Press at the source. Linux/macOS only ever emit Press, so this is a no-op there and safe cross-platform.